### PR TITLE
Add base_footprint to urdf

### DIFF
--- a/mirte_description/mirte_master_description/urdf/mirte_master.xacro
+++ b/mirte_description/mirte_master_description/urdf/mirte_master.xacro
@@ -191,6 +191,15 @@
     </joint>
   </xacro:if>
 
+  <xacro:property name="wheel_zoff" value="0.05"/>
+  <link name="base_footprint"/>
+  <joint name="base_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="base_footprint"/>
+    <origin xyz="0.0 0.0 ${-(wheel_radius + wheel_zoff)}" rpy="0 0 0"/>
+  </joint>
+
+
   <xacro:if value="$(arg sonar_enable)">
     <xacro:include filename="$(find mirte_master_description)/urdf/ultrasonic.xacro" />
 
@@ -295,6 +304,7 @@
   <xacro:if value="$(arg arm_enable)">
     <xacro:include filename="$(find mirte_master_description)/urdf/arm.xacro" />
   </xacro:if>
+
 
 
 </robot>


### PR DESCRIPTION
The base_footprint link is needed for nav2: https://docs.nav2.org/setup_guides/urdf/setup_urdf.html

The wheel_zoff value in `<xacro:property name="wheel_zoff" value="0.05"/>` needs to be adjusted to make the base_footprint link be in the center of the robot.